### PR TITLE
Add jquery typeahead

### DIFF
--- a/app/assets/sass/application.scss
+++ b/app/assets/sass/application.scss
@@ -28,3 +28,49 @@ $path: "/public/images/";
 }
 
 // Add extra styles here, or re-organise the Sass files in whichever way makes most sense to you
+
+.typeahead,
+.tt-query,
+.tt-hint {
+  font-size: 19px;
+  line-height: 1.25;
+  font-weight: 300;
+  text-transform: none;
+  border: 1px solid #bbb;
+  margin: 0;
+  padding: 0.5em;
+}
+
+.tt-hint{
+  display: none;
+}
+
+.tt-menu {
+  padding: 0;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  width: 100%;
+}
+
+.tt-suggestion {
+  padding: 0.5em;
+  font-size: 19px;
+  line-height: 24px;
+}
+
+.tt-suggestion p{
+  margin: 0;
+}
+
+.tt-suggestion.tt-cursor {
+  color: #fff;
+  background-color: #0097cf;
+}
+
+.twitter-typeahead {
+  width: 100%;
+
+  .validation-wrapper .optional-section & input {
+    margin-bottom: 0;
+  }
+}

--- a/docs/views/examples/elements/forms2.html
+++ b/docs/views/examples/elements/forms2.html
@@ -44,71 +44,22 @@
 
   <script type="text/javascript">
     $(document).ready(function () {
-      var states = new Bloodhound({
-        datumTokenizer: Bloodhound.tokenizers.whitespace,
-        queryTokenizer: Bloodhound.tokenizers.whitespace,
-        local: [
-          'Alabama',
-          'Alaska',
-          'Arizona',
-          'Arkansas',
-          'California',
-          'Colorado',
-          'Connecticut',
-          'Delaware',
-          'Florida',
-          'Georgia',
-          'Hawaii',
-          'Idaho',
-          'Illinois',
-          'Indiana',
-          'Iowa',
-          'Kansas',
-          'Kentucky',
-          'Louisiana',
-          'Maine',
-          'Maryland',
-          'Massachusetts',
-          'Michigan',
-          'Minnesota',
-          'Mississippi',
-          'Missouri',
-          'Montana',
-          'Nebraska',
-          'Nevada',
-          'New Hampshire',
-          'New Jersey',
-          'New Mexico',
-          'New York',
-          'North Carolina',
-          'North Dakota',
-          'Ohio',
-          'Oklahoma',
-          'Oregon',
-          'Pennsylvania',
-          'Rhode Island',
-          'South Carolina',
-          'South Dakota',
-          'Tennessee',
-          'Texas',
-          'Utah',
-          'Vermont',
-          'Virginia',
-          'Washington',
-          'West Virginia',
-          'Wisconsin',
-          'Wyoming'
-        ]
-      })
+      $.get('https://country.register.gov.uk/records.json?page-size=500', function (result) {
+        var countries = Object.keys(result).map(k => result[k])
+        var countryNames = countries.map(c => c.name)
 
-      states.initialize()
+        var states = new Bloodhound({
+          datumTokenizer: Bloodhound.tokenizers.whitespace,
+          queryTokenizer: Bloodhound.tokenizers.whitespace,
+          local: countryNames
+        })
 
-      $('#country-select-box').typeahead(
-        {},
-        {
+        $('#country-select-box').typeahead({
+          hint: false
+        }, {
           source: states
-        }
-      )
+        })
+      })
     })
   </script>
 {% endblock %}

--- a/docs/views/examples/elements/forms2.html
+++ b/docs/views/examples/elements/forms2.html
@@ -27,9 +27,88 @@
 
   </form>
 
-  <script type="text/javascript">
-    console.log('hi')
-  </script>
-
 </main>
+{% endblock %}
+
+{% block body_end %}
+  <!-- Javascript -->
+  <script src="/public/javascripts/details.polyfill.js"></script>
+  <script src="/public/javascripts/jquery-1.11.3.js"></script>
+  <script src="/public/javascripts/govuk/selection-buttons.js"></script>
+  <script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
+  <script src="/public/javascripts/govuk/show-hide-content.js"></script>
+  <script src="/public/javascripts/application.js"></script>
+  <!-- GOV.UK Prototype kit {{releaseVersion}} -->
+
+  <script src="/public/typeahead.bundle.min.js"></script>
+
+  <script type="text/javascript">
+    $(document).ready(function () {
+      var states = new Bloodhound({
+        datumTokenizer: Bloodhound.tokenizers.whitespace,
+        queryTokenizer: Bloodhound.tokenizers.whitespace,
+        local: [
+          'Alabama',
+          'Alaska',
+          'Arizona',
+          'Arkansas',
+          'California',
+          'Colorado',
+          'Connecticut',
+          'Delaware',
+          'Florida',
+          'Georgia',
+          'Hawaii',
+          'Idaho',
+          'Illinois',
+          'Indiana',
+          'Iowa',
+          'Kansas',
+          'Kentucky',
+          'Louisiana',
+          'Maine',
+          'Maryland',
+          'Massachusetts',
+          'Michigan',
+          'Minnesota',
+          'Mississippi',
+          'Missouri',
+          'Montana',
+          'Nebraska',
+          'Nevada',
+          'New Hampshire',
+          'New Jersey',
+          'New Mexico',
+          'New York',
+          'North Carolina',
+          'North Dakota',
+          'Ohio',
+          'Oklahoma',
+          'Oregon',
+          'Pennsylvania',
+          'Rhode Island',
+          'South Carolina',
+          'South Dakota',
+          'Tennessee',
+          'Texas',
+          'Utah',
+          'Vermont',
+          'Virginia',
+          'Washington',
+          'West Virginia',
+          'Wisconsin',
+          'Wyoming'
+        ]
+      })
+
+      states.initialize()
+
+      $('#country-select-box').typeahead(
+        {},
+        {
+          source: states
+        }
+      )
+    })
+  </script>
 {% endblock %}

--- a/docs/views/examples/elements/forms2.html
+++ b/docs/views/examples/elements/forms2.html
@@ -1,0 +1,35 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Example - Forms
+{% endblock %}
+
+{% block content %}
+<main id="content" role="main">
+
+  {% include "includes/breadcrumb_examples.html" %}
+
+  <form action="/docs/tutorials-and-examples" method="post" class="form">
+
+    <h1 class="form-title heading-large">
+      Country picker
+    </h1>
+
+    <!-- Country picker -->
+     <div class="form-group">
+      <label class="form-label-bold" for="country-select-box">Country</label>
+      <input type="text" class="form-control" id="country-select-box" placeholder="Country">
+    </div>
+
+    <div class="form-group">
+      <input type="submit" class="button" value="Continue">
+    </div>
+
+  </form>
+
+  <script type="text/javascript">
+    console.log('hi')
+  </script>
+
+</main>
+{% endblock %}

--- a/gulp/copy-modules.js
+++ b/gulp/copy-modules.js
@@ -27,3 +27,8 @@ gulp.task('copy-elements-sass', function () {
   return gulp.src(['node_modules/govuk-elements-sass/public/sass/**'])
   .pipe(gulp.dest(config.paths.govukModules + '/govuk-elements-sass/'))
 })
+
+gulp.task('copy-typeahead', function () {
+  return gulp.src(['node_modules/corejs-typeahead/dist/**'])
+  .pipe(gulp.dest(config.paths.govukModules + '/corejs-typeahead/'))
+})

--- a/gulp/tasks.js
+++ b/gulp/tasks.js
@@ -27,7 +27,8 @@ gulp.task('copy-govuk-modules', [
   'copy-toolkit',
   'copy-template-assets',
   'copy-elements-sass',
-  'copy-template'
+  'copy-template',
+  'copy-typeahead'
 ])
 
 gulp.task('watch', function (done) {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "basic-auth-connect": "^1.0.0",
     "body-parser": "^1.14.1",
     "browser-sync": "^2.11.1",
+    "corejs-typeahead": "^1.1.0",
     "cross-spawn": "^5.0.0",
     "express": "4.13.3",
     "express-session": "^1.13.0",

--- a/server.js
+++ b/server.js
@@ -61,6 +61,7 @@ app.set('view engine', 'html')
 app.use('/public', express.static(path.join(__dirname, '/public')))
 app.use('/public', express.static(path.join(__dirname, '/govuk_modules/govuk_template/assets')))
 app.use('/public', express.static(path.join(__dirname, '/govuk_modules/govuk_frontend_toolkit')))
+app.use('/public', express.static(path.join(__dirname, '/govuk_modules/corejs-typeahead')))
 app.use('/public/images/icons', express.static(path.join(__dirname, '/govuk_modules/govuk_frontend_toolkit/images')))
 
 // Elements refers to icon folder instead of images folder


### PR DESCRIPTION
This adds another examples page, forms2.html, which contains an example of hooking up
[corejs-typeahead](https://github.com/corejavascript/typeahead.js) into a list of countries based off of the registers API.

The next step is to transform this to make use of synonyms, using Andy's dependency graph example.

# After

![screen shot 2017-01-05 at 14 02 50](https://cloud.githubusercontent.com/assets/1650875/21683115/e8876222-d34f-11e6-86b3-f8e89284c940.png)

