### PR TITLE
Clean up example pages, update homepage

### DIFF
--- a/app/config.js
+++ b/app/config.js
@@ -4,7 +4,7 @@
 
 module.exports = {
   // Service name used in header. Eg: 'Renew your passport'
-  serviceName: 'Service name goes here',
+  serviceName: 'Country Picker Prototypes',
 
   // Default port that prototype runs on
   port: '3000',

--- a/app/views/country-picker-1.html
+++ b/app/views/country-picker-1.html
@@ -7,8 +7,6 @@
 {% block content %}
 <main id="content" role="main">
 
-  {% include "includes/breadcrumb_examples.html" %}
-
   <form action="/docs/tutorials-and-examples" method="post" class="form">
 
     <h1 class="form-title heading-large">

--- a/app/views/country-picker-1.html
+++ b/app/views/country-picker-1.html
@@ -69,7 +69,7 @@
         }
       }
 
-      loadJSON('https://country.register.gov.uk/records.json', function (data) {
+      loadJSON('https://country.register.gov.uk/records.json?page-size=500', function (data) {
         var countries = Object.keys(data).map(function (k) {
           return data[k]
         })

--- a/app/views/country-picker-1.html
+++ b/app/views/country-picker-1.html
@@ -1,0 +1,90 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Example - Forms
+{% endblock %}
+
+{% block content %}
+<main id="content" role="main">
+
+  {% include "includes/breadcrumb_examples.html" %}
+
+  <form action="/docs/tutorials-and-examples" method="post" class="form">
+
+    <h1 class="form-title heading-large">
+      Country picker
+    </h1>
+
+    <!-- Country picker -->
+     <div class="form-group">
+      <label class="form-label-bold" for="country-select-box">Country</label>
+      <input type="text" class="form-control" id="country-find" placeholder="Country" onkeyup="searchCountry()">
+      <br>
+      <br>
+      <select class="form-control" id="country-select-box">
+        <option>Select...</option>
+      </select>
+    </div>
+
+    <div class="form-group">
+      <input type="submit" class="button" value="Continue">
+    </div>
+
+  </form>
+
+  <script type="text/javascript">
+    //(function () {
+      'use strict'
+
+      function loadJSON (path, success, error) {
+        var xhr = new XMLHttpRequest()
+        xhr.onreadystatechange = function () {
+          if (xhr.readyState === XMLHttpRequest.DONE) {
+            if (xhr.status === 200) {
+              if (success) {
+                success(JSON.parse(xhr.responseText))
+              }
+            } else {
+              if (error) {
+                error(xhr)
+              }
+            }
+          }
+        }
+        xhr.open('GET', path, true)
+        xhr.send()
+      }
+
+      var countryOptions = '',
+          countryInput = document.getElementById('country-find'),
+          countrySelect = document.getElementById('country-select-box')
+
+      function searchCountry () {
+        var input = countryInput.value.toLowerCase(),
+            output = countrySelect.options
+        for (var i = 0; i < output.length; i++) {
+          if (output[i].value.indexOf(input) === 0) {
+            output[i].selected = true
+          }
+        }
+      }
+
+      loadJSON('https://country.register.gov.uk/records.json', function (data) {
+        var countries = Object.keys(data).map(function (k) {
+          return data[k]
+        })
+
+        for (var i = 0; i < countries.length; i++) {
+          countryOptions += '<option value="' + countries[i]['official-name'].toLowerCase() + '">' + countries[i]['official-name'] + '</option>'
+        }
+
+        countrySelect.innerHTML = countryOptions
+      }, function (xhr) {
+        console.error(xhr)
+      })
+    //})(window)
+
+  </script>
+
+</main>
+{% endblock %}

--- a/app/views/country-picker-2.html
+++ b/app/views/country-picker-2.html
@@ -7,8 +7,6 @@
 {% block content %}
 <main id="content" role="main">
 
-  {% include "includes/breadcrumb_examples.html" %}
-
   <form action="/docs/tutorials-and-examples" method="post" class="form">
 
     <h1 class="form-title heading-large">

--- a/app/views/country-picker-2.html
+++ b/app/views/country-picker-2.html
@@ -1,0 +1,65 @@
+{% extends "layout.html" %}
+
+{% block page_title %}
+  Example - Forms
+{% endblock %}
+
+{% block content %}
+<main id="content" role="main">
+
+  {% include "includes/breadcrumb_examples.html" %}
+
+  <form action="/docs/tutorials-and-examples" method="post" class="form">
+
+    <h1 class="form-title heading-large">
+      Country picker
+    </h1>
+
+    <!-- Country picker -->
+     <div class="form-group">
+      <label class="form-label-bold" for="country-select-box">Country</label>
+      <input type="text" class="form-control" id="country-select-box" placeholder="Country">
+    </div>
+
+    <div class="form-group">
+      <input type="submit" class="button" value="Continue">
+    </div>
+
+  </form>
+
+</main>
+{% endblock %}
+
+{% block body_end %}
+  <!-- Javascript -->
+  <script src="/public/javascripts/details.polyfill.js"></script>
+  <script src="/public/javascripts/jquery-1.11.3.js"></script>
+  <script src="/public/javascripts/govuk/selection-buttons.js"></script>
+  <script src="/public/javascripts/govuk/shim-links-with-button-role.js"></script>
+  <script src="/public/javascripts/govuk/show-hide-content.js"></script>
+  <script src="/public/javascripts/application.js"></script>
+  <!-- GOV.UK Prototype kit {{releaseVersion}} -->
+
+  <script src="/public/typeahead.bundle.min.js"></script>
+
+  <script type="text/javascript">
+    $(document).ready(function () {
+      $.get('https://country.register.gov.uk/records.json?page-size=500', function (result) {
+        var countries = Object.keys(result).map(k => result[k])
+        var countryNames = countries.map(c => c.name)
+
+        var states = new Bloodhound({
+          datumTokenizer: Bloodhound.tokenizers.whitespace,
+          queryTokenizer: Bloodhound.tokenizers.whitespace,
+          local: countryNames
+        })
+
+        $('#country-select-box').typeahead({
+          hint: false
+        }, {
+          source: states
+        })
+      })
+    })
+  </script>
+{% endblock %}

--- a/app/views/index.html
+++ b/app/views/index.html
@@ -11,54 +11,33 @@
     <div class="column-two-thirds">
 
       <h1 class="heading-xlarge">
-        The GOV.UK prototype kit
-        <span class="heading-secondary">{{releaseVersion}}</span>
-      </h1>{{releaseVersion | log }}
-      <p>
-        This kit lets you rapidly create HTML prototypes of GOV.UK services.
-      </p>
+        Country Picker Prototypes
+      </h1>
+
+      <p>These are country picker widgets that read data from the <a href="https://country.register.gov.uk/" target="_blank">country register</a>.</p>
+
+      <h2 class="heading-medium"><a href="/country-picker-1">Example 1: Plain JavaScript + plain register</a></h2>
 
       <p>
-        It contains all you need to prototype anything from simple static pages to complex, data-driven transactions.
+        This example uses plain JavaScript to query a public register, and populates a
+        <code>&lt;select&gt;</code> element. It demonstrates one of the simplest ways to query a
+        register and present the results to the user.
       </p>
 
-      <h2 class="heading-medium">About this page</h2>
+      <h2 class="heading-medium"><a href="/country-picker-2">Example 2: jQuery Typeahead + plain register</a></h2>
 
-      <p>We recommend you add links to your prototype to this page, rather than delete it.
-        You'll find this page in the kit at '/app/views/index.html'.</p>
-      <p>You can change the service name by editing the file '/app/config.js'.</p>
+      <p>
+        This example uses the <a href="https://github.com/corejavascript/typeahead.js" target="_blank">corejs-typeahead</a> jQuery plugin and populates it using
+        the same data from Example 1. It demonstrates one way to use an off the
+        shelf component with a public register.
+      </p>
 
-			<h2 class="heading-medium">Examples and documentation</h2>
+      <h2 class="heading-medium"><a href="#">Example 3: jQuery Typeahead + register data file</a></h2>
 
-			<ul class="list list-bullet">
-				<li><a href="/docs/tutorials-and-examples">Example pages and documentation</a></li>
-				<li><a href="https://github.com/alphagov/govuk_prototype_kit">GitHub</a></li>
-			</ul>
-
-      <h2 class="heading-medium">Other resources</h2>
-
-			<ul class="list list-bullet">
-				<li>
-					<a href="https://govuk-elements.herokuapp.com/snippets/">
-						Guide to GOV.UK Elements
-					</a>
-				</li>
-				<li>
-					<a href="https://www.gov.uk/service-manual">
-						Service design manual
-					</a>
-				</li>
-				<li>
-					<a href="https://www.gov.uk/design-principles">
-						Government Digital Service Design Principles
-					</a>
-				</li>
-			</ul>
+      <p>Coming soon.</p>
 
     </div>
   </div>
 </main>
 
 {% endblock %}
-
-


### PR DESCRIPTION
Some prep to get this ready to deploy on Heroku and make it a little more self documenting.

- Update the service name
- Make the country pickers live on better URLs
- Update the homepage content, add a little spiel about each picker
- Remove breadcrumbs from the country picker examples
- Update `?page-size` in the first example

# Homepage after

![screen shot 2017-01-06 at 10 31 36](https://cloud.githubusercontent.com/assets/1650875/21715249/4df5f2a8-d3fb-11e6-9624-e25ad47e06c0.png)
